### PR TITLE
[RMQ-1756] Bump go : Fixes CVE-2025-22874

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rabbitmq/default-user-credential-updater
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.24.4
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
CVE fixed in latest `1.24.4` go version:
https://pkg.go.dev/vuln/GO-2025-3749

Reported by TVS:
https://tpe-tvs.acc.broadcom.net/artifact?selectedBuildId=18544&selectedBuildVersion=1.0.6&selectedComponentName=rabbitmq-default-user-updater&selectedComponentId=396958

