### PR TITLE
ci: update github actions permissions and registries

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -34,8 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit_tests
     permissions:
-      contents: 'write'
-      id-token: 'write'
+      contents: 'read'
       packages: 'write'
     steps:
     - uses: actions/checkout@v6
@@ -51,7 +50,6 @@ jobs:
       uses: docker/metadata-action@v6
       with:
         images: |
-          rabbitmqoperator/default-user-credential-updater
           quay.io/rabbitmqoperator/default-user-credential-updater
           ghcr.io/rabbitmq/default-user-credential-updater
         tags: |
@@ -62,12 +60,6 @@ jobs:
     - uses: docker/setup-qemu-action@v4
 
     - uses: docker/setup-buildx-action@v4
-
-    - uses: docker/login-action@v4
-      if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to Quay.io
       if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Summary

- Remove unnecessary OIDC 'id-token' and 'write' contents permissions from the build-test-publish workflow. 
- Remove DockerHub login and image publication since we are moving away from DockerHub.
