### PR TITLE
CI : Update permissions to create GH release

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -99,7 +99,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [ unit_tests, build_dev_image ]
     permissions:
-      contents: 'read'
+      contents: 'write'
     steps:
     - uses: actions/checkout@v7
 


### PR DESCRIPTION
Recently updated `read` permissions is causing the release job to fail when creating a GitHub release:
https://github.com/rabbitmq/default-user-credential-updater/actions/runs/29320168335/job/87045136325