### PR TITLE
Fix release actions permissions.

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -99,7 +99,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [ unit_tests, build_dev_image ]
     permissions:
-      contents: 'read'
+      contents: write
     steps:
     - uses: actions/checkout@v7
 


### PR DESCRIPTION
Write permissions needed for release notes, see
https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#generate-release-notes-content-for-a-release

[ai-assisted=no]